### PR TITLE
It was installed simplehttpserver with a python3 command and change the command to use it.

### DIFF
--- a/04-Account-Setup/cloud_shell_and_editor/simple-http-server-web-preview.txt
+++ b/04-Account-Setup/cloud_shell_and_editor/simple-http-server-web-preview.txt
@@ -1,6 +1,8 @@
 SimpleHTTPServer example
 
 Initialize Cloud Shell
+Maybe you will have to install SimpleHTTPServer in your Cloud Shell terminal, use this command:
+"python3 -m pip install simple_http_server" (https://pypi.org/project/simple-http-server/)
 Copy and paste this python code right into the Cloud Shell
 
 cd `mktemp -d` \

--- a/04-Account-Setup/cloud_shell_and_editor/simple-http-server-web-preview.txt
+++ b/04-Account-Setup/cloud_shell_and_editor/simple-http-server-web-preview.txt
@@ -5,7 +5,7 @@ Copy and paste this python code right into the Cloud Shell
 
 cd `mktemp -d` \
     && echo '<html><h1>Hello World</h1></html>' >./index.html \
-    && python -m SimpleHTTPServer 8080
+    && python3 -m http.server 8080
 
 Hit Enter
 Click on the "Web Preview" button


### PR DESCRIPTION
Hi Antoni, I'm studying for my Associate Cloud Engineer Certification with your course in freeCodeCamp youtube channel. 

In the module 4 I had to install simplehttpserver using a command for python3, after that the command you used to launch the server changed. I think that this changes maybe help other students. 

Thanks.