### PR TITLE
Update public source image to the latest supported

### DIFF
--- a/07-Compute-Engine/05_deployment_manager/templates/bowtie-webserver.jinja
+++ b/07-Compute-Engine/05_deployment_manager/templates/bowtie-webserver.jinja
@@ -10,7 +10,7 @@ resources:
       boot: true
       autoDelete: true
       initializeParams:
-        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9
+        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20220822
     metadata:
       items:
       - key: startup-script


### PR DESCRIPTION
Public image from of Debian 9 family has been retired and no longer supported by Google therefore causes deployment to fail.